### PR TITLE
Fix blank page from duplicate module script

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,5 @@
     <div id="root"></div>
     <!-- This single script is transpiled by Babel and contains the entire application logic -->
      <script type="text/babel" data-type="module" data-presets="react,typescript" src="/index.tsx"></script>
-  <script type="module" src="/index.tsx"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove second script tag that loaded index.tsx as a module

The duplicate tag attempted to load the raw TSX module without Babel and resulted in a blank page in production.

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68858c4cb5908331924bb7a5fc537196