### PR TITLE
Fix blank page by removing old React scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Inspiration Now</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <!-- Load React and ReactDOM from CDN. This makes them available as global variables: window.React and window.ReactDOM -->
-    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <!-- Load Babel for in-browser JSX/TS transpilation -->
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
     <style>
@@ -34,6 +31,5 @@
     <div id="root"></div>
     <!-- This single script is transpiled by Babel and contains the entire application logic -->
      <script type="text/babel" data-type="module" data-presets="react,typescript" src="/index.tsx"></script>
-  <script type="module" src="/index.tsx"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove global React/ReactDOM scripts from `index.html`

The page already loads React via the import map. The additional global versions could conflict and prevent the app from rendering.

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68858c4cb5908331924bb7a5fc537196