### PR TITLE
Fix script tag for Babel to enable module imports

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,11 @@
   <body class="bg-gray-100">
     <div id="root"></div>
     <!-- This single script is transpiled by Babel and contains the entire application logic -->
-     <script type="text/babel" data-presets="react,typescript" src="/index.tsx"></script>
+    <script
+      type="text/babel"
+      data-presets="react,typescript"
+      data-type="module"
+      src="/index.tsx"
+    ></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- instruct Babel to treat index.tsx as ES module so `import` works

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688590faa5308331b2461fcf88876e8b